### PR TITLE
Add support for the automatic dev runtime

### DIFF
--- a/index.js
+++ b/index.js
@@ -361,28 +361,28 @@ export function buildJsx(tree, options = {}) {
                 }
               ]
             }
-            if (node.loc?.start.line !== undefined) {
-              source.properties.push({
-                type: 'Property',
-                method: false,
-                shorthand: false,
-                computed: false,
-                kind: 'init',
-                key: {type: 'Identifier', name: 'lineNumber'},
-                value: {type: 'Literal', value: node.loc.start.line}
-              })
-            }
 
-            if (node.loc?.start.column !== undefined) {
-              source.properties.push({
-                type: 'Property',
-                method: false,
-                shorthand: false,
-                computed: false,
-                kind: 'init',
-                key: {type: 'Identifier', name: 'columnNumber'},
-                value: {type: 'Literal', value: node.loc.start.column + 1}
-              })
+            if (node.loc) {
+              source.properties.push(
+                {
+                  type: 'Property',
+                  method: false,
+                  shorthand: false,
+                  computed: false,
+                  kind: 'init',
+                  key: {type: 'Identifier', name: 'lineNumber'},
+                  value: {type: 'Literal', value: node.loc.start.line}
+                },
+                {
+                  type: 'Property',
+                  method: false,
+                  shorthand: false,
+                  computed: false,
+                  kind: 'init',
+                  key: {type: 'Identifier', name: 'columnNumber'},
+                  value: {type: 'Literal', value: node.loc.start.column + 1}
+                }
+              )
             }
 
             parameters.push(source)

--- a/index.js
+++ b/index.js
@@ -329,12 +329,7 @@ export function buildJsx(tree, options = {}) {
         if (key) {
           parameters.push(key)
         } else if (options.development) {
-          parameters.push({
-            type: 'UnaryExpression',
-            operator: 'void',
-            prefix: true,
-            argument: {type: 'Literal', value: 0}
-          })
+          parameters.push({type: 'Identifier', name: 'undefined'})
         }
 
         const isStaticChildren = children.length > 1

--- a/index.js
+++ b/index.js
@@ -342,51 +342,49 @@ export function buildJsx(tree, options = {}) {
           }
           parameters.push({type: 'Literal', value: isStaticChildren})
 
-          if (options.filePath) {
-            /** @type {ObjectExpression} */
-            const source = {
-              type: 'ObjectExpression',
-              properties: [
-                {
-                  type: 'Property',
-                  method: false,
-                  shorthand: false,
-                  computed: false,
-                  kind: 'init',
-                  key: {type: 'Identifier', name: 'fileName'},
-                  value: {type: 'Literal', value: options.filePath}
+          /** @type {ObjectExpression} */
+          const source = {
+            type: 'ObjectExpression',
+            properties: [
+              {
+                type: 'Property',
+                method: false,
+                shorthand: false,
+                computed: false,
+                kind: 'init',
+                key: {type: 'Identifier', name: 'fileName'},
+                value: {
+                  type: 'Literal',
+                  value: options.filePath || '<source.js>'
                 }
-              ]
-            }
-
-            if (node.loc) {
-              source.properties.push(
-                {
-                  type: 'Property',
-                  method: false,
-                  shorthand: false,
-                  computed: false,
-                  kind: 'init',
-                  key: {type: 'Identifier', name: 'lineNumber'},
-                  value: {type: 'Literal', value: node.loc.start.line}
-                },
-                {
-                  type: 'Property',
-                  method: false,
-                  shorthand: false,
-                  computed: false,
-                  kind: 'init',
-                  key: {type: 'Identifier', name: 'columnNumber'},
-                  value: {type: 'Literal', value: node.loc.start.column + 1}
-                }
-              )
-            }
-
-            parameters.push(source)
-          } else {
-            parameters.push({type: 'Identifier', name: 'undefined'})
+              }
+            ]
           }
-          parameters.push({type: 'ThisExpression'})
+
+          if (node.loc) {
+            source.properties.push(
+              {
+                type: 'Property',
+                method: false,
+                shorthand: false,
+                computed: false,
+                kind: 'init',
+                key: {type: 'Identifier', name: 'lineNumber'},
+                value: {type: 'Literal', value: node.loc.start.line}
+              },
+              {
+                type: 'Property',
+                method: false,
+                shorthand: false,
+                computed: false,
+                kind: 'init',
+                key: {type: 'Identifier', name: 'columnNumber'},
+                value: {type: 'Literal', value: node.loc.start.column + 1}
+              }
+            )
+          }
+
+          parameters.push(source, {type: 'ThisExpression'})
         } else if (isStaticChildren) {
           imports.jsxs = true
           callee = {type: 'Identifier', name: '_jsxs'}

--- a/index.js
+++ b/index.js
@@ -346,6 +346,7 @@ export function buildJsx(tree, options = {}) {
             name: '_jsxDEV'
           }
           parameters.push({type: 'Literal', value: isStaticChildren})
+
           if (options.filePath) {
             /** @type {ObjectExpression} */
             const source = {

--- a/index.js
+++ b/index.js
@@ -338,6 +338,7 @@ export function buildJsx(tree, options = {}) {
         }
 
         const isStaticChildren = children.length > 1
+
         if (options.development) {
           imports.jsxDEV = true
           callee = {

--- a/index.js
+++ b/index.js
@@ -361,7 +361,7 @@ export function buildJsx(tree, options = {}) {
                 }
               ]
             }
-            if (node.loc?.start.line != null) {
+            if (node.loc?.start.line !== undefined) {
               source.properties.push({
                 type: 'Property',
                 method: false,
@@ -372,7 +372,8 @@ export function buildJsx(tree, options = {}) {
                 value: {type: 'Literal', value: node.loc.start.line}
               })
             }
-            if (node.loc?.start.column != null) {
+
+            if (node.loc?.start.column !== undefined) {
               source.properties.push({
                 type: 'Property',
                 method: false,
@@ -383,6 +384,7 @@ export function buildJsx(tree, options = {}) {
                 value: {type: 'Literal', value: node.loc.start.column + 1}
               })
             }
+
             parameters.push(source)
           }
         } else if (isStaticChildren) {

--- a/index.js
+++ b/index.js
@@ -383,7 +383,10 @@ export function buildJsx(tree, options = {}) {
             }
 
             parameters.push(source)
+          } else {
+            parameters.push({type: 'Identifier', name: 'undefined'})
           }
+          parameters.push({type: 'ThisExpression'})
         } else if (isStaticChildren) {
           imports.jsxs = true
           callee = {type: 'Identifier', name: '_jsxs'}

--- a/readme.md
+++ b/readme.md
@@ -120,8 +120,9 @@ development mode (`boolean`, default: `false`).
 
 ###### `options.filePath`
 
-If the automatic runtime development mode is used, this option is used to
-provide a file path to map the JSX node to a source file (`string`).
+File path to the original source file (`string`, example: `'path/to/file.js'`).
+Used in the location info when using the automatic runtime with
+`development: true`.
 
 ###### `options.pragma`
 

--- a/readme.md
+++ b/readme.md
@@ -116,12 +116,12 @@ Note that `/jsx-runtime` is appended to this provided source.
 ##### `options.development`
 
 If the automatic runtime is used, this compiles JSX into automatic runtime
-development mode. (`boolean`, default: `false`)
+development mode (`boolean`, default: `false`).
 
 ###### `options.filePath`
 
 If the automatic runtime development mode is used, this option is used to
-provide a file path to map the JSX node to a source file. (`string`)
+provide a file path to map the JSX node to a source file (`string`).
 
 ###### `options.pragma`
 

--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,7 @@ Note that `/jsx-runtime` is appended to this provided source.
 Add location info on where a component originated from (`boolean`, default:
 `false`).
 This helps debugging but adds a lot of code that you don’t want in production.
-Only used when `filePath` is and in the automatic runtime.
+Only used in the automatic runtime.
 
 ###### `options.filePath`
 

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,16 @@ runtime is automatic (`string`, default: `'react'`).
 Comment: `@jsxImportSource theSource`.
 Note that `/jsx-runtime` is appended to this provided source.
 
+##### `options.development`
+
+If the automatic runtime is used, this compiles JSX into automatic runtime
+development mode. (`boolean`, default: `false`)
+
+###### `options.filePath`
+
+If the automatic runtime development mode is used, this option is used to
+provide a file path to map the JSX node to a source file. (`string`)
+
 ###### `options.pragma`
 
 Identifier or member expression to call when the effective runtime is classic

--- a/readme.md
+++ b/readme.md
@@ -115,8 +115,10 @@ Note that `/jsx-runtime` is appended to this provided source.
 
 ##### `options.development`
 
-If the automatic runtime is used, this compiles JSX into automatic runtime
-development mode (`boolean`, default: `false`).
+Add location info on where a component originated from (`boolean`, default:
+`false`).
+This helps debugging but adds a lot of code that you don’t want in production.
+Only used when `filePath` is and in the automatic runtime.
 
 ###### `options.filePath`
 

--- a/test.js
+++ b/test.js
@@ -1244,7 +1244,7 @@ test('estree-util-build-jsx', (t) => {
       'import {Fragment as _Fragment, jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
       '_jsxDEV(_Fragment, {',
       '  children: "a"',
-      '}, void 0, false, {',
+      '}, undefined, false, {',
       '  fileName: "index.js",',
       '  lineNumber: 1,',
       '  columnNumber: 1',
@@ -1290,7 +1290,7 @@ test('estree-util-build-jsx', (t) => {
       '  b: "1"',
       '}, c, {',
       '  children: "d"',
-      '}), void 0, false, {',
+      '}), undefined, false, {',
       '  fileName: "index.js",',
       '  lineNumber: 1,',
       '  columnNumber: 1',
@@ -1316,7 +1316,7 @@ test('estree-util-build-jsx', (t) => {
       '}, {',
       '  d: "e",',
       '  children: "f"',
-      '}), void 0, false, {',
+      '}), undefined, false, {',
       '  fileName: "index.js",',
       '  lineNumber: 1,',
       '  columnNumber: 1',
@@ -1338,7 +1338,7 @@ test('estree-util-build-jsx', (t) => {
       'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
       '_jsxDEV("a", {',
       '  children: "b"',
-      '}, void 0, false, {',
+      '}, undefined, false, {',
       '  fileName: "index.js",',
       '  lineNumber: 1,',
       '  columnNumber: 1',
@@ -1358,7 +1358,7 @@ test('estree-util-build-jsx', (t) => {
     ),
     [
       'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
-      '_jsxDEV("a", {}, void 0, false, {',
+      '_jsxDEV("a", {}, undefined, false, {',
       '  fileName: "index.js",',
       '  lineNumber: 1,',
       '  columnNumber: 1',
@@ -1397,7 +1397,7 @@ test('estree-util-build-jsx', (t) => {
     ),
     [
       'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
-      '_jsxDEV("a", {}, void 0, false);',
+      '_jsxDEV("a", {}, undefined, false);',
       ''
     ].join('\n'),
     'should support the automatic runtime (no props, no children, development, no filePath)'
@@ -1413,7 +1413,7 @@ test('estree-util-build-jsx', (t) => {
     ),
     [
       'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
-      '_jsxDEV("a", {}, void 0, false, {',
+      '_jsxDEV("a", {}, undefined, false, {',
       '  fileName: "index.js"',
       '});',
       ''
@@ -1432,12 +1432,12 @@ test('estree-util-build-jsx', (t) => {
     [
       'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
       '_jsxDEV("a", {',
-      '  children: _jsxDEV("b", {}, void 0, false, {',
+      '  children: _jsxDEV("b", {}, undefined, false, {',
       '    fileName: "index.js",',
       '    lineNumber: 2,',
       '    columnNumber: 3',
       '  })',
-      '}, void 0, false, {',
+      '}, undefined, false, {',
       '  fileName: "index.js",',
       '  lineNumber: 1,',
       '  columnNumber: 1',

--- a/test.js
+++ b/test.js
@@ -1421,6 +1421,32 @@ test('estree-util-build-jsx', (t) => {
     'should support the automatic runtime (no props, no children, development, no locations)'
   )
 
+  t.deepEqual(
+    generate(
+      buildJsx(parse('<a>\n  <b />\n</a>', false), {
+        runtime: 'automatic',
+        development: true,
+        filePath: 'index.js'
+      })
+    ),
+    [
+      'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
+      '_jsxDEV("a", {',
+      '  children: _jsxDEV("b", {}, void 0, false, {',
+      '    fileName: "index.js",',
+      '    lineNumber: 2,',
+      '    columnNumber: 3',
+      '  })',
+      '}, void 0, false, {',
+      '  fileName: "index.js",',
+      '  lineNumber: 1,',
+      '  columnNumber: 1',
+      '});',
+      ''
+    ].join('\n'),
+    'should support the automatic runtime (no props, nested children, development, positional info)'
+  )
+
   t.throws(
     () => {
       buildJsx(parse('<a {...b} key/>'), {runtime: 'automatic'})

--- a/test.js
+++ b/test.js
@@ -1248,7 +1248,7 @@ test('estree-util-build-jsx', (t) => {
       '  fileName: "index.js",',
       '  lineNumber: 1,',
       '  columnNumber: 1',
-      '});',
+      '}, this);',
       ''
     ].join('\n'),
     'should support the automatic runtime (fragment, jsx, settings, development)'
@@ -1270,7 +1270,7 @@ test('estree-util-build-jsx', (t) => {
       '  fileName: "index.js",',
       '  lineNumber: 1,',
       '  columnNumber: 1',
-      '});',
+      '}, this);',
       ''
     ].join('\n'),
     'should support the automatic runtime (jsxs, key, comment, development)'
@@ -1294,7 +1294,7 @@ test('estree-util-build-jsx', (t) => {
       '  fileName: "index.js",',
       '  lineNumber: 1,',
       '  columnNumber: 1',
-      '});',
+      '}, this);',
       ''
     ].join('\n'),
     'should support the automatic runtime (props, spread, children, development)'
@@ -1320,7 +1320,7 @@ test('estree-util-build-jsx', (t) => {
       '  fileName: "index.js",',
       '  lineNumber: 1,',
       '  columnNumber: 1',
-      '});',
+      '}, this);',
       ''
     ].join('\n'),
     'should support the automatic runtime (spread, props, children, development)'
@@ -1342,7 +1342,7 @@ test('estree-util-build-jsx', (t) => {
       '  fileName: "index.js",',
       '  lineNumber: 1,',
       '  columnNumber: 1',
-      '});',
+      '}, this);',
       ''
     ].join('\n'),
     'should support the automatic runtime (no props, children, development)'
@@ -1362,7 +1362,7 @@ test('estree-util-build-jsx', (t) => {
       '  fileName: "index.js",',
       '  lineNumber: 1,',
       '  columnNumber: 1',
-      '});',
+      '}, this);',
       ''
     ].join('\n'),
     'should support the automatic runtime (no props, no children, development)'
@@ -1382,7 +1382,7 @@ test('estree-util-build-jsx', (t) => {
       '  fileName: "index.js",',
       '  lineNumber: 1,',
       '  columnNumber: 1',
-      '});',
+      '}, this);',
       ''
     ].join('\n'),
     'should support the automatic runtime (key, no props, no children, development)'
@@ -1397,7 +1397,7 @@ test('estree-util-build-jsx', (t) => {
     ),
     [
       'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
-      '_jsxDEV("a", {}, undefined, false);',
+      '_jsxDEV("a", {}, undefined, false, undefined, this);',
       ''
     ].join('\n'),
     'should support the automatic runtime (no props, no children, development, no filePath)'
@@ -1415,7 +1415,7 @@ test('estree-util-build-jsx', (t) => {
       'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
       '_jsxDEV("a", {}, undefined, false, {',
       '  fileName: "index.js"',
-      '});',
+      '}, this);',
       ''
     ].join('\n'),
     'should support the automatic runtime (no props, no children, development, no locations)'
@@ -1436,12 +1436,12 @@ test('estree-util-build-jsx', (t) => {
       '    fileName: "index.js",',
       '    lineNumber: 2,',
       '    columnNumber: 3',
-      '  })',
+      '  }, this)',
       '}, undefined, false, {',
       '  fileName: "index.js",',
       '  lineNumber: 1,',
       '  columnNumber: 1',
-      '});',
+      '}, this);',
       ''
     ].join('\n'),
     'should support the automatic runtime (no props, nested children, development, positional info)'

--- a/test.js
+++ b/test.js
@@ -1397,10 +1397,34 @@ test('estree-util-build-jsx', (t) => {
     ),
     [
       'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
-      '_jsxDEV("a", {}, undefined, false, undefined, this);',
+      '_jsxDEV("a", {}, undefined, false, {',
+      '  fileName: "<source.js>",',
+      '  lineNumber: 1,',
+      '  columnNumber: 1',
+      '}, this);',
       ''
     ].join('\n'),
     'should support the automatic runtime (no props, no children, development, no filePath)'
+  )
+
+  t.deepEqual(
+    generate(
+      buildJsx(parse('<a />', false), {
+        runtime: 'automatic',
+        development: true,
+        filePath: ''
+      })
+    ),
+    [
+      'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
+      '_jsxDEV("a", {}, undefined, false, {',
+      '  fileName: "<source.js>",',
+      '  lineNumber: 1,',
+      '  columnNumber: 1',
+      '}, this);',
+      ''
+    ].join('\n'),
+    'should support the automatic runtime (no props, no children, development, empty filePath)'
   )
 
   t.deepEqual(

--- a/test.js
+++ b/test.js
@@ -1232,6 +1232,195 @@ test('estree-util-build-jsx', (t) => {
     'should support the automatic runtime (key, no props, no children)'
   )
 
+  t.deepEqual(
+    generate(
+      buildJsx(parse('<>a</>', false), {
+        runtime: 'automatic',
+        development: true,
+        filePath: 'index.js'
+      })
+    ),
+    [
+      'import {Fragment as _Fragment, jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
+      '_jsxDEV(_Fragment, {',
+      '  children: "a"',
+      '}, void 0, false, {',
+      '  fileName: "index.js",',
+      '  lineNumber: 1,',
+      '  columnNumber: 1',
+      '});',
+      ''
+    ].join('\n'),
+    'should support the automatic runtime (fragment, jsx, settings, development)'
+  )
+
+  t.deepEqual(
+    generate(
+      buildJsx(parse('<a key="a">b{1}</a>', false), {
+        runtime: 'automatic',
+        development: true,
+        filePath: 'index.js'
+      })
+    ),
+    [
+      'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
+      '_jsxDEV("a", {',
+      '  children: ["b", 1]',
+      '}, "a", true, {',
+      '  fileName: "index.js",',
+      '  lineNumber: 1,',
+      '  columnNumber: 1',
+      '});',
+      ''
+    ].join('\n'),
+    'should support the automatic runtime (jsxs, key, comment, development)'
+  )
+
+  t.deepEqual(
+    generate(
+      buildJsx(parse('<a b="1" {...c}>d</a>', false), {
+        runtime: 'automatic',
+        development: true,
+        filePath: 'index.js'
+      })
+    ),
+    [
+      'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
+      '_jsxDEV("a", Object.assign({',
+      '  b: "1"',
+      '}, c, {',
+      '  children: "d"',
+      '}), void 0, false, {',
+      '  fileName: "index.js",',
+      '  lineNumber: 1,',
+      '  columnNumber: 1',
+      '});',
+      ''
+    ].join('\n'),
+    'should support the automatic runtime (props, spread, children, development)'
+  )
+
+  t.deepEqual(
+    generate(
+      buildJsx(parse('<a {...{b: 1, c: 2}} d="e">f</a>', false), {
+        runtime: 'automatic',
+        development: true,
+        filePath: 'index.js'
+      })
+    ),
+    [
+      'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
+      '_jsxDEV("a", Object.assign({',
+      '  b: 1,',
+      '  c: 2',
+      '}, {',
+      '  d: "e",',
+      '  children: "f"',
+      '}), void 0, false, {',
+      '  fileName: "index.js",',
+      '  lineNumber: 1,',
+      '  columnNumber: 1',
+      '});',
+      ''
+    ].join('\n'),
+    'should support the automatic runtime (spread, props, children, development)'
+  )
+
+  t.deepEqual(
+    generate(
+      buildJsx(parse('<a>b</a>', false), {
+        runtime: 'automatic',
+        development: true,
+        filePath: 'index.js'
+      })
+    ),
+    [
+      'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
+      '_jsxDEV("a", {',
+      '  children: "b"',
+      '}, void 0, false, {',
+      '  fileName: "index.js",',
+      '  lineNumber: 1,',
+      '  columnNumber: 1',
+      '});',
+      ''
+    ].join('\n'),
+    'should support the automatic runtime (no props, children, development)'
+  )
+
+  t.deepEqual(
+    generate(
+      buildJsx(parse('<a/>', false), {
+        runtime: 'automatic',
+        development: true,
+        filePath: 'index.js'
+      })
+    ),
+    [
+      'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
+      '_jsxDEV("a", {}, void 0, false, {',
+      '  fileName: "index.js",',
+      '  lineNumber: 1,',
+      '  columnNumber: 1',
+      '});',
+      ''
+    ].join('\n'),
+    'should support the automatic runtime (no props, no children, development)'
+  )
+
+  t.deepEqual(
+    generate(
+      buildJsx(parse('<a key/>', false), {
+        runtime: 'automatic',
+        development: true,
+        filePath: 'index.js'
+      })
+    ),
+    [
+      'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
+      '_jsxDEV("a", {}, true, false, {',
+      '  fileName: "index.js",',
+      '  lineNumber: 1,',
+      '  columnNumber: 1',
+      '});',
+      ''
+    ].join('\n'),
+    'should support the automatic runtime (key, no props, no children, development)'
+  )
+
+  t.deepEqual(
+    generate(
+      buildJsx(parse('<a />', false), {
+        runtime: 'automatic',
+        development: true
+      })
+    ),
+    [
+      'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
+      '_jsxDEV("a", {}, void 0, false);',
+      ''
+    ].join('\n'),
+    'should support the automatic runtime (no props, no children, development, no filePath)'
+  )
+
+  t.deepEqual(
+    generate(
+      buildJsx(parse('<a />'), {
+        runtime: 'automatic',
+        development: true,
+        filePath: 'index.js'
+      })
+    ),
+    [
+      'import {jsxDEV as _jsxDEV} from "react/jsx-dev-runtime";',
+      '_jsxDEV("a", {}, void 0, false, {',
+      '  fileName: "index.js"',
+      '});',
+      ''
+    ].join('\n'),
+    'should support the automatic runtime (no props, no children, development, no locations)'
+  )
+
   t.throws(
     () => {
       buildJsx(parse('<a {...b} key/>'), {runtime: 'automatic'})


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

This was discussed in https://github.com/mdx-js/mdx/issues/2035. The only difference that wasn’t discussed is that the automatic runtime import is also changed from `/jsx-runtime` to `/jsx-dev-runtime`.

The `source` parameter is still missing, as its meaning is not clear to me. It’s not required anyway, so this should be fine.

<!--do not edit: pr-->
