### PR TITLE
Update dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
   },
   "devDependencies": {
     "@types/escodegen": "^0.0.7",
-    "@types/node": "^18.0.0",
+    "@types/node": "^20.0.0",
     "acorn": "^8.0.0",
     "acorn-jsx": "^5.0.0",
     "astring": "^1.0.0",
-    "c8": "^7.0.0",
+    "c8": "^8.0.0",
     "escodegen": "^2.0.0",
     "nyc": "^15.0.0",
     "prettier": "^2.0.0",
@@ -59,8 +59,8 @@
     "remark-cli": "^11.0.0",
     "remark-preset-wooorm": "^9.0.0",
     "type-coverage": "^2.0.0",
-    "typescript": "^4.0.0",
-    "xo": "^0.53.0"
+    "typescript": "^5.0.0",
+    "xo": "^0.54.0"
   },
   "scripts": {
     "prepack": "npm run build && npm run format",

--- a/test.js
+++ b/test.js
@@ -3,7 +3,6 @@ import test from 'node:test'
 import {Parser} from 'acorn'
 import jsx from 'acorn-jsx'
 import {walk} from 'estree-walker'
-// @ts-expect-error: typed incorrectly.
 import {generate} from 'astring'
 import recast from 'recast'
 import escodegen from 'escodegen'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,8 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "exactOptionalPropertyTypes": true,
-    "forceConsistentCasingInFileNames": true,
     "lib": ["es2020"],
     "module": "node16",
-    "newLine": "lf",
     "strict": true,
     "target": "es2020"
   }


### PR DESCRIPTION
### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

TypeScript 5 changed some defaults, making some options redundant.

`astring` fixed their type definitions, so `@ts-expect-error` was removed.

<!--do not edit: pr-->
